### PR TITLE
Update generated theme config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,39 @@ Omarchy-nix includes several predefined themes:
 - `gruvbox`
 - `gruvbox-light`
 
-You can also generate a custom theme from any wallpaper image:
+You can also generate themes from wallpaper images using:
+- `generated_light` - generates a light color scheme from wallpaper
+- `generated_dark` - generates a dark color scheme from wallpaper
+
+Generated themes require a wallpaper path to be specified:
 
 ```nix
 {
   omarchy = {
-    theme = "custom";
-    customTheme = {
-      wallpaperPath = ./path/to/your/wallpaper.png;
-      variant = "dark"; # or "light" for light themes
+    theme = "generated_dark"; # or "generated_light"
+    theme_overrides = {
+      wallpaper_path = ./path/to/your/wallpaper.png;
     };
   };
 }
 ```
 
-This will automatically extract colors from your wallpaper and generate a matching color scheme for all Omarchy applications (terminal, editor, launcher, etc.). 
+#### Wallpaper Overrides
+
+Any theme can be customized with a custom wallpaper by specifying `wallpaper_path` in theme_overrides. For predefined themes, this will only change the wallpaper but keep the original color scheme:
+
+```nix
+{
+  omarchy = {
+    theme = "tokyo-night"; # or any other predefined theme
+    theme_overrides = {
+      wallpaper_path = ./path/to/your/wallpaper.png;
+    };
+  };
+}
+```
+
+Generated themes automatically extract colors from the wallpaper and create a matching color scheme for all Omarchy applications (terminal, editor, launcher, etc.). 
 
 ## License
 

--- a/config.nix
+++ b/config.nix
@@ -17,27 +17,23 @@ lib: {
         "nord"
         "gruvbox"
         "gruvbox-light"
-        "custom"
+        "generated_light"
+        "generated_dark"
       ]) lib.types.str;
       default = "tokyo-night";
       description = "Theme to use for Omarchy configuration";
     };
-    customTheme = lib.mkOption {
+    theme_overrides = lib.mkOption {
       type = lib.types.submodule {
         options = {
-          wallpaperPath = lib.mkOption {
+          wallpaper_path = lib.mkOption {
             type = lib.types.path;
             description = "Path to the wallpaper image to extract colors from";
-          };
-          variant = lib.mkOption {
-            type = lib.types.enum [ "light" "dark" ];
-            default = "dark";
-            description = "Color scheme variant to extract (light or dark)";
           };
         };
       };
       default = {};
-      description = "Custom theme configuration when theme is set to 'custom'";
+      description = "Theme overrides including wallpaper path for generated themes";
     };
     primary_font = lib.mkOption {
       type = lib.types.str;

--- a/config.nix
+++ b/config.nix
@@ -27,7 +27,8 @@ lib: {
       type = lib.types.submodule {
         options = {
           wallpaper_path = lib.mkOption {
-            type = lib.types.path;
+            type = lib.types.nullOr lib.types.path;
+            default = null;
             description = "Path to the wallpaper image to extract colors from";
           };
         };

--- a/lib/selected-wallpaper.nix
+++ b/lib/selected-wallpaper.nix
@@ -22,7 +22,7 @@ config: let
   };
 
   # Handle wallpaper path for generated themes and overrides
-  wallpaper_path = if (cfg.theme == "generated_light" || cfg.theme == "generated_dark") || (cfg.theme_overrides ? wallpaper_path)
+  wallpaper_path = if (cfg.theme == "generated_light" || cfg.theme == "generated_dark") || (cfg.theme_overrides.wallpaper_path != null)
     then toString cfg.theme_overrides.wallpaper_path
     else let
       selected_wallpaper = builtins.elemAt (wallpapers.${cfg.theme}) 0;

--- a/lib/selected-wallpaper.nix
+++ b/lib/selected-wallpaper.nix
@@ -21,9 +21,9 @@ config: let
     ];
   };
 
-  # Handle custom wallpaper path
-  wallpaper_path = if cfg.theme == "custom"
-    then toString cfg.customTheme.wallpaperPath
+  # Handle wallpaper path for generated themes and overrides
+  wallpaper_path = if (cfg.theme == "generated_light" || cfg.theme == "generated_dark") || (cfg.theme_overrides ? wallpaper_path)
+    then toString cfg.theme_overrides.wallpaper_path
     else let
       selected_wallpaper = builtins.elemAt (wallpapers.${cfg.theme}) 0;
     in "~/Pictures/Wallpapers/${selected_wallpaper}";

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -14,7 +14,7 @@ inputs: {
     else themes.${config.omarchy.theme};
   
   # Generate color scheme from wallpaper for generated themes
-  generatedColorScheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark") || (config.omarchy.theme_overrides ? wallpaper_path)
+  generatedColorScheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark") 
     then (inputs.nix-colors.lib.contrib { inherit pkgs; }).colorSchemeFromPicture {
       path = config.omarchy.theme_overrides.wallpaper_path;
       variant = if config.omarchy.theme == "generated_light" then "light" else "dark";
@@ -47,7 +47,7 @@ in {
   };
   home.packages = packages.homePackages;
 
-  colorScheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark") || (config.omarchy.theme_overrides ? wallpaper_path)
+  colorScheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark")
     then generatedColorScheme
     else inputs.nix-colors.colorSchemes.${selectedTheme.base16-theme};
 

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -8,16 +8,16 @@ inputs: {
 
   themes = import ../themes.nix;
   
-  # Handle theme selection - either predefined or custom
-  selectedTheme = if config.omarchy.theme == "custom"
-    then themes.custom
+  # Handle theme selection - either predefined or generated
+  selectedTheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark")
+    then null
     else themes.${config.omarchy.theme};
   
-  # Generate color scheme - either from predefined or from wallpaper
-  generatedColorScheme = if config.omarchy.theme == "custom"
+  # Generate color scheme from wallpaper for generated themes
+  generatedColorScheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark") || (config.omarchy.theme_overrides ? wallpaper_path)
     then (inputs.nix-colors.lib.contrib { inherit pkgs; }).colorSchemeFromPicture {
-      path = config.omarchy.customTheme.wallpaperPath;
-      variant = config.omarchy.customTheme.variant;
+      path = config.omarchy.theme_overrides.wallpaper_path;
+      variant = if config.omarchy.theme == "generated_light" then "light" else "dark";
     }
     else null;
 in {
@@ -47,7 +47,7 @@ in {
   };
   home.packages = packages.homePackages;
 
-  colorScheme = if config.omarchy.theme == "custom"
+  colorScheme = if (config.omarchy.theme == "generated_light" || config.omarchy.theme == "generated_dark") || (config.omarchy.theme_overrides ? wallpaper_path)
     then generatedColorScheme
     else inputs.nix-colors.colorSchemes.${selectedTheme.base16-theme};
 

--- a/modules/home-manager/waybar.nix
+++ b/modules/home-manager/waybar.nix
@@ -6,6 +6,7 @@ inputs: {
   palette = config.colorScheme.palette;
   convert = inputs.nix-colors.lib.conversions.hexToRGBString;
   backgroundRgb = "rgb(${convert ", " palette.base00})";
+  foregroundRgb = "rgb(${convert ", " palette.base05})";
 in {
   home.file = {
     ".config/waybar/" = {
@@ -16,7 +17,7 @@ in {
       text = ''
         @define-color background ${backgroundRgb};
         * {
-          color: white; 
+          color: ${foregroundRgb}; 
         }
 
         window#waybar {


### PR DESCRIPTION
Was noodling on #6 and came to the conclusion that "custom" wasn't necessarily the best naming for wallpaper-generated color schemes, I envision a near-future effort to allow users to specify their own base16 color schemes in the config without having to rely on our presets.

I also took this time to decouple wallpapers from the generated themes, this allows users to use inbuilt Omarchy themes but override the wallpaper however they so choose.

Also fixxed a bug in waybar for light mode themes.