### PR TITLE
arm64 support

### DIFF
--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -1,4 +1,4 @@
-{pkgs, lib, exclude_packages ? []}: 
+{pkgs, lib, exclude_packages ? []}:
 let
   # Essential Hyprland packages - cannot be excluded
   hyprlandPackages = with pkgs; [
@@ -47,11 +47,6 @@ let
     vlc
     signal-desktop
 
-    # Commercial GUIs
-    typora
-    dropbox
-    spotify
-
     # Development tools
     github-desktop
     gh
@@ -59,6 +54,10 @@ let
     # Containers
     docker-compose
     ffmpeg
+  ] ++ lib.optionals (pkgs.system == "x86_64-linux") [
+    typora
+    dropbox
+    spotify
   ];
 
   # Only allow excluding discretionary packages to prevent breaking the system


### PR DESCRIPTION
Greetings, and thanks for your work.

This PR appends x86_64-linux exclusive packages only when on that arch. This allows this flake to be useful on ARM64.

Adding these packages to `exclude_packages` when on ARM64 does not work because `exclude_packages` will still try to evaluate those packages (and fail) -- this PR fixes that.