### PR TITLE
Update input.nix

### DIFF
--- a/modules/home-manager/hyprland/input.nix
+++ b/modules/home-manager/hyprland/input.nix
@@ -11,7 +11,7 @@
       kb_layout = "us";
       # kb_variant =
       # kb_model =
-      kb_options = compose:caps;
+      kb_options = "compose:caps";
       # kb_rules =
 
       follow_mouse = 1;


### PR DESCRIPTION
building the system configuration...
warning: Git tree '/home/coco/nixos-dotfiles' is dirty error:
       … while calling the 'head' builtin
         at /nix/store/x2k3b38vdbrpxsf262lpwlmpf8nggbxj-source/lib/attrsets.nix:1534:13:
         1533|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1534|             head values
             |             ^
         1535|           else

       … while evaluating the attribute 'value'
         at /nix/store/x2k3b38vdbrpxsf262lpwlmpf8nggbxj-source/lib/modules.nix:1083:7:
         1082|     // {
         1083|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1084|       inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: URL literals are deprecated, allow using them with --extra-deprecated-features url-literals
       at /nix/store/l1xywynici5593h7ml1h05rkhx3j92qp-source/modules/home-manager/hyprland/input.nix:14:20:
           13|       # kb_model =
           14|       kb_options = compose:caps;
             |                    ^
           15|       # kb_rules =