### PR TITLE
fixing build failure against current nixos-unstable: error: 'noto-fon…

### DIFF
--- a/modules/nixos/system.nix
+++ b/modules/nixos/system.nix
@@ -41,7 +41,7 @@ in
 
   fonts.packages = with pkgs; [
     noto-fonts
-    noto-fonts-emoji
+    noto-fonts-color-emoji
     nerd-fonts.caskaydia-mono
   ];
 }


### PR DESCRIPTION
…ts-emoji' has been renamed to/replaced by 'noto-fonts-color-emoji'