### PR TITLE
Add Hyprland killapp key binding customization & separate Hyprlock wallpaper support

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -78,6 +78,14 @@ lib: {
         "SUPER, slash, exec, $passwordManager"
       ];
     };
+    kill_app_binding = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "SUPER, W, killactive,"
+        "SUPER, Backspace, killactive,"
+      ];
+      description = "Packages to exclude from the default system packages";
+    };
     exclude_packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];

--- a/config.nix
+++ b/config.nix
@@ -36,6 +36,11 @@ lib: {
       default = { };
       description = "Theme overrides including wallpaper path for generated themes";
     };
+    hyprlock_wallpaper = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to the hyprlock wallpaper => fallback to the theme wallpaper if not specify";
+    };
     primary_font = lib.mkOption {
       type = lib.types.str;
       default = "Liberation Sans 11";

--- a/lib/selected-wallpaper.nix
+++ b/lib/selected-wallpaper.nix
@@ -24,7 +24,9 @@ let
 
   # Handle wallpaper path for generated themes and overrides
   wallpaper_path =
-    if
+    if (cfg.hyprlock_wallpaper != null) then
+      toString cfg.hyprlock_wallpaper
+    else if
       (cfg.theme == "generated_light" || cfg.theme == "generated_dark")
       || (cfg.theme_overrides.wallpaper_path != null)
     then

--- a/lib/selected-wallpaper.nix
+++ b/lib/selected-wallpaper.nix
@@ -24,9 +24,7 @@ let
 
   # Handle wallpaper path for generated themes and overrides
   wallpaper_path =
-    if (cfg.hyprlock_wallpaper != null) then
-      toString cfg.hyprlock_wallpaper
-    else if
+    if
       (cfg.theme == "generated_light" || cfg.theme == "generated_dark")
       || (cfg.theme_overrides.wallpaper_path != null)
     then

--- a/modules/home-manager/hyprland/bindings.nix
+++ b/modules/home-manager/hyprland/bindings.nix
@@ -8,97 +8,97 @@ let
 in
 {
   wayland.windowManager.hyprland.settings = {
-    bind = cfg.quick_app_bindings ++ [
-      "SUPER, space, exec, wofi --show drun --sort-order=alphabetical"
-      "SUPER SHIFT, SPACE, exec, pkill -SIGUSR1 waybar"
-      # "SUPER CTRL, SPACE, exec, ~/.local/share/omarchy/bin/swaybg-next"
-      # "SUPER SHIFT CTRL, SPACE, exec, ~/.local/share/omarchy/bin/omarchy-theme-next"
+    bind =
+      cfg.quick_app_bindings
+      ++ cfg.kill_app_binding
+      ++ [
+        "SUPER, space, exec, wofi --show drun --sort-order=alphabetical"
+        "SUPER SHIFT, SPACE, exec, pkill -SIGUSR1 waybar"
+        # "SUPER CTRL, SPACE, exec, ~/.local/share/omarchy/bin/swaybg-next"
+        # "SUPER SHIFT CTRL, SPACE, exec, ~/.local/share/omarchy/bin/omarchy-theme-next"
 
-      "SUPER, W, killactive,"
-      "SUPER, Backspace, killactive,"
+        # End active session
+        "SUPER, ESCAPE, exec, hyprlock"
+        "SUPER SHIFT, ESCAPE, exit,"
+        "SUPER CTRL, ESCAPE, exec, reboot"
+        "SUPER SHIFT CTRL, ESCAPE, exec, systemctl poweroff"
+        "SUPER, K, exec, ~/.local/share/omarchy/bin/omarchy-show-keybindings"
 
-      # End active session
-      "SUPER, ESCAPE, exec, hyprlock"
-      "SUPER SHIFT, ESCAPE, exit,"
-      "SUPER CTRL, ESCAPE, exec, reboot"
-      "SUPER SHIFT CTRL, ESCAPE, exec, systemctl poweroff"
-      "SUPER, K, exec, ~/.local/share/omarchy/bin/omarchy-show-keybindings"
+        # Control tiling
+        "SUPER, J, togglesplit, # dwindle"
+        "SUPER, P, pseudo, # dwindle"
+        "SUPER, V, togglefloating,"
+        "SUPER SHIFT, Plus, fullscreen,"
 
-      # Control tiling
-      "SUPER, J, togglesplit, # dwindle"
-      "SUPER, P, pseudo, # dwindle"
-      "SUPER, V, togglefloating,"
-      "SUPER SHIFT, Plus, fullscreen,"
+        # Move focus with mainMod + arrow keys
+        "SUPER, left, movefocus, l"
+        "SUPER, right, movefocus, r"
+        "SUPER, up, movefocus, u"
+        "SUPER, down, movefocus, d"
 
-      # Move focus with mainMod + arrow keys
-      "SUPER, left, movefocus, l"
-      "SUPER, right, movefocus, r"
-      "SUPER, up, movefocus, u"
-      "SUPER, down, movefocus, d"
+        # Switch workspaces with mainMod + [0-9]
+        "SUPER, 1, workspace, 1"
+        "SUPER, 2, workspace, 2"
+        "SUPER, 3, workspace, 3"
+        "SUPER, 4, workspace, 4"
+        "SUPER, 5, workspace, 5"
+        "SUPER, 6, workspace, 6"
+        "SUPER, 7, workspace, 7"
+        "SUPER, 8, workspace, 8"
+        "SUPER, 9, workspace, 9"
+        "SUPER, 0, workspace, 10"
 
-      # Switch workspaces with mainMod + [0-9]
-      "SUPER, 1, workspace, 1"
-      "SUPER, 2, workspace, 2"
-      "SUPER, 3, workspace, 3"
-      "SUPER, 4, workspace, 4"
-      "SUPER, 5, workspace, 5"
-      "SUPER, 6, workspace, 6"
-      "SUPER, 7, workspace, 7"
-      "SUPER, 8, workspace, 8"
-      "SUPER, 9, workspace, 9"
-      "SUPER, 0, workspace, 10"
+        "SUPER, comma, workspace, -1"
+        "SUPER, period, workspace, +1"
 
-      "SUPER, comma, workspace, -1"
-      "SUPER, period, workspace, +1"
+        # Move active window to a workspace with mainMod + SHIFT + [0-9]
+        "SUPER SHIFT, 1, movetoworkspace, 1"
+        "SUPER SHIFT, 2, movetoworkspace, 2"
+        "SUPER SHIFT, 3, movetoworkspace, 3"
+        "SUPER SHIFT, 4, movetoworkspace, 4"
+        "SUPER SHIFT, 5, movetoworkspace, 5"
+        "SUPER SHIFT, 6, movetoworkspace, 6"
+        "SUPER SHIFT, 7, movetoworkspace, 7"
+        "SUPER SHIFT, 8, movetoworkspace, 8"
+        "SUPER SHIFT, 9, movetoworkspace, 9"
+        "SUPER SHIFT, 0, movetoworkspace, 10"
 
-      # Move active window to a workspace with mainMod + SHIFT + [0-9]
-      "SUPER SHIFT, 1, movetoworkspace, 1"
-      "SUPER SHIFT, 2, movetoworkspace, 2"
-      "SUPER SHIFT, 3, movetoworkspace, 3"
-      "SUPER SHIFT, 4, movetoworkspace, 4"
-      "SUPER SHIFT, 5, movetoworkspace, 5"
-      "SUPER SHIFT, 6, movetoworkspace, 6"
-      "SUPER SHIFT, 7, movetoworkspace, 7"
-      "SUPER SHIFT, 8, movetoworkspace, 8"
-      "SUPER SHIFT, 9, movetoworkspace, 9"
-      "SUPER SHIFT, 0, movetoworkspace, 10"
+        # Swap active window with the one next to it with mainMod + SHIFT + arrow keys
+        "SUPER SHIFT, left, swapwindow, l"
+        "SUPER SHIFT, right, swapwindow, r"
+        "SUPER SHIFT, up, swapwindow, u"
+        "SUPER SHIFT, down, swapwindow, d"
 
-      # Swap active window with the one next to it with mainMod + SHIFT + arrow keys
-      "SUPER SHIFT, left, swapwindow, l"
-      "SUPER SHIFT, right, swapwindow, r"
-      "SUPER SHIFT, up, swapwindow, u"
-      "SUPER SHIFT, down, swapwindow, d"
+        # Resize active window
+        "SUPER, minus, resizeactive, -100 0"
+        "SUPER, equal, resizeactive, 100 0"
+        "SUPER SHIFT, minus, resizeactive, 0 -100"
+        "SUPER SHIFT, equal, resizeactive, 0 100"
 
-      # Resize active window
-      "SUPER, minus, resizeactive, -100 0"
-      "SUPER, equal, resizeactive, 100 0"
-      "SUPER SHIFT, minus, resizeactive, 0 -100"
-      "SUPER SHIFT, equal, resizeactive, 0 100"
+        # Scroll through existing workspaces with mainMod + scroll
+        "SUPER, mouse_down, workspace, e+1"
+        "SUPER, mouse_up, workspace, e-1"
 
-      # Scroll through existing workspaces with mainMod + scroll
-      "SUPER, mouse_down, workspace, e+1"
-      "SUPER, mouse_up, workspace, e-1"
+        # Control Apple Display brightness
+        "CTRL, F1, exec, ~/.local/share/omarchy/bin/apple-display-brightness -5000"
+        "CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000"
+        "SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000"
 
-      # Control Apple Display brightness
-      "CTRL, F1, exec, ~/.local/share/omarchy/bin/apple-display-brightness -5000"
-      "CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000"
-      "SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000"
+        # Super workspace floating layer
+        "SUPER, S, togglespecialworkspace, magic"
+        "SUPER SHIFT, S, movetoworkspace, special:magic"
 
-      # Super workspace floating layer
-      "SUPER, S, togglespecialworkspace, magic"
-      "SUPER SHIFT, S, movetoworkspace, special:magic"
+        # Screenshots
+        ", PRINT, exec, hyprshot -m region"
+        "SHIFT, PRINT, exec, hyprshot -m window"
+        "CTRL, PRINT, exec, hyprshot -m output"
 
-      # Screenshots
-      ", PRINT, exec, hyprshot -m region"
-      "SHIFT, PRINT, exec, hyprshot -m window"
-      "CTRL, PRINT, exec, hyprshot -m output"
+        # Color picker
+        "SUPER, PRINT, exec, hyprpicker -a"
 
-      # Color picker
-      "SUPER, PRINT, exec, hyprpicker -a"
-
-      # Clipse
-      "CTRL SUPER, V, exec, ghostty --class clipse -e clipse"
-    ];
+        # Clipse
+        "CTRL SUPER, V, exec, ghostty --class clipse -e clipse"
+      ];
 
     bindm = [
       # Move/resize windows with mainMod + LMB/RMB and dragging

--- a/modules/home-manager/hyprlock.nix
+++ b/modules/home-manager/hyprlock.nix
@@ -8,7 +8,11 @@ inputs:
 let
   palette = config.colorScheme.palette;
   convert = inputs.nix-colors.lib.conversions.hexToRGBString;
-  selected_wallpaper_path = (import ../../lib/selected-wallpaper.nix config).wallpaper_path;
+  selected_wallpaper_path =
+    if (config.hyprlock_wallpaper != null) then
+      config.hyprlock_wallpaper
+    else
+      (import ../../lib/selected-wallpaper.nix config).wallpaper_path;
 
   backgroundRgb = "rgba(${convert ", " palette.base00}, 0.8)";
   surfaceRgb = "rgb(${convert ", " palette.base02})";

--- a/modules/home-manager/hyprlock.nix
+++ b/modules/home-manager/hyprlock.nix
@@ -9,8 +9,8 @@ let
   palette = config.colorScheme.palette;
   convert = inputs.nix-colors.lib.conversions.hexToRGBString;
   selected_wallpaper_path =
-    if (config.hyprlock_wallpaper != null) then
-      config.hyprlock_wallpaper
+    if (config.omarchy.hyprlock_wallpaper != null) then
+      toString config.omarchy.hyprlock_wallpaper
     else
       (import ../../lib/selected-wallpaper.nix config).wallpaper_path;
 


### PR DESCRIPTION
## Description

This PR introduces new customization options for Hyprland bindings and Hyprlock wallpaper configuration, improving flexibility and user control.

## Changes:
- Added a new option to customize the Hyprlock wallpaper independently, instead of relying on selected_wallpaper.nix.
- Added a new option to customize the key binding used to close applications.

## Benefits
Allows users to set a different wallpaper for Hyprlock without affecting the main wallpaper.
Enables personalized key bindings to better match user preferences or keyboard layouts.
Improves overall configurability while keeping existing behavior intact by default.

## Example configuration 

``` 
{
  pkgs,
  lib,
  ...
}:
{
  # * Check implementation here:  https://github.com/henrysipp/omarchy-nix
  omarchy = {
    full_name = "";
    email_address = "";
    theme = "everforest";
    hyprlock_wallpaper = ./../../assets/wallpapers/a_rainbow_colored_logo_with_an_apple.png;
    exclude_packages = with pkgs; [
      vscode
      spotify
      typora
      dropbox
    ];
    scale = 1;
    quick_app_bindings = [
      "SUPER, slash, exec, $passwordManager --ozone-platform=wayland --enable-features=UseOzonePlatform"
      "CTRL SHIFT, space, exec, $passwordManager --quick-access --ozone-platform=wayland --enable-features=UseOzonePlatform"

      "SUPER, B, exec, $browser"
      "SUPER, C, exec, $webapp=https://claude.com"

      "SUPER, D, exec, $terminal -e lazydocker"

      "SUPER, T, exec, $terminal"
      "SUPER, F, exec, $fileManager"
      "SUPER, N, exec, $terminal -e nvim"
      "SUPER, M, exec, $terminal -e btop"
      "SUPER, S, exec, $messenger"
    ];
    kill_app_binding = [
      "SUPER, Q, killactive,"
    ];
  };
}
```